### PR TITLE
Updated numpy/f2py/capi_maps.py to fix security vulnerability [python.lang.security.audit.eval-detected.eval-detected]

### DIFF
--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -1,3 +1,4 @@
+import ast
 """
 Copyright 1999 -- 2011 Pearu Peterson all rights reserved.
 Copyright 2011 -- present NumPy Developers.
@@ -154,7 +155,7 @@ def load_f2cmap_file(f2cmap_file):
     try:
         outmess(f'Reading f2cmap from {f2cmap_file!r} ...\n')
         with open(f2cmap_file) as f:
-            d = eval(f.read().lower(), {}, {})
+            d = ast.literal_eval(f.read().lower(), {}, {})
         f2cmap_all, f2cmap_mapped = process_f2cmap_dict(f2cmap_all, d, c2py_map, True)
         outmess('Successfully applied user defined f2cmap changes\n')
     except Exception as msg:
@@ -291,7 +292,7 @@ def getarrdims(a, var, verbose=0):
         dim = copy.copy(var['dimension'])
         ret['size'] = '*'.join(dim)
         try:
-            ret['size'] = repr(eval(ret['size']))
+            ret['size'] = repr(ast.literal_eval(ret['size']))
         except Exception:
             pass
         ret['dims'] = ','.join(dim)
@@ -444,7 +445,7 @@ def getinit(a, var):
                     ret['init.r'], ret['init.i'] = markoutercomma(
                         v[1:-1]).split('@,@')
                 else:
-                    v = eval(v, {}, {})
+                    v = ast.literal_eval(v, {}, {})
                     ret['init.r'], ret['init.i'] = str(v.real), str(v.imag)
             except Exception:
                 raise ValueError(


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Detected the use of eval(). eval() can be dangerous if used to evaluate dynamic content. If this content can be input from outside the program, this may be a code injection vulnerability. Ensure evaluated content is not definable by external sources.
- **Rule ID:** python.lang.security.audit.eval-detected.eval-detected
- **Severity:** HIGH
- **File:** numpy/f2py/capi_maps.py
- **Lines Affected:** 157 - 157

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `numpy/f2py/capi_maps.py` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.
