### PR TITLE
Updated numpy/distutils/fcompiler/gnu.py to fix security vulnerability [python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1]

### DIFF
--- a/numpy/distutils/fcompiler/gnu.py
+++ b/numpy/distutils/fcompiler/gnu.py
@@ -399,7 +399,7 @@ class Gnu95FCompiler(GnuFCompiler):
         return ""
 
     def _hash_files(self, filenames):
-        h = hashlib.sha1()
+        h = hashlib.sha256()
         for fn in filenames:
             with open(fn, 'rb') as f:
                 while True:


### PR DESCRIPTION
**Context and Purpose:**

            This PR automatically remediates a security vulnerability:
            - **Description:** Detected SHA1 hash algorithm which is considered insecure. SHA1 is not collision resistant and is therefore not suitable as a cryptographic signature. Use SHA256 or SHA3 instead.
            - **Rule ID:** python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
            - **Severity:** MEDIUM
            - **File:** numpy/distutils/fcompiler/gnu.py
            - **Lines Affected:** 402 - 402

            This change is necessary to protect the application from potential security risks associated with this vulnerability.

            **Solution Implemented:**

            The automated remediation process has applied the necessary changes to the affected code in `numpy/distutils/fcompiler/gnu.py` to resolve the identified issue.

            Please review the changes to ensure they are correct and integrate as expected.
            